### PR TITLE
Fetch missions - Fetch data #18

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,8 @@
 		],
 		"react/react-in-jsx-scope": "off",
 		"import/no-unresolved": "off",
-		"no-shadow": "off"
+		"no-shadow": "off",
+		"no-param-reassign": ["error", { "props": true, "ignorePropertyModificationsFor": ["state"] }]
 	},
 	"ignorePatterns": [
 		"dist/",

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/pages/Missions.js
+++ b/src/components/pages/Missions.js
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchMissions } from '../../redux/missions/missionSlice';
 
-function Missions() {
+const Missions = () => {
+  const dispatch = useDispatch();
+  const { missions } = useSelector((state) => state.mission);
+  console.log(missions);
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch, fetchMissions]);
   return (
     <div>
       missions under construction
     </div>
   );
-}
+};
 
 export default Missions;

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rocketsSlice from './rockets/rocketsSlice';
+import missionsSlice from './missions/missionSlice';
 
 const store = configureStore({
   reducer: {
     rockets: rocketsSlice.reducer,
+    mission: missionsSlice,
   },
 });
 

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -1,0 +1,34 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+// import axios from 'axios';
+
+const initialState = {
+  missions: [],
+};
+const missionsURL = 'https://api.spacexdata.com/v3/missions';
+export const fetchMissions = createAsyncThunk(
+  'missions/fetchMissions',
+  async () => {
+    const response = await fetch(missionsURL);
+    if (response.ok) {
+      const data = await response.json();
+      console.log(data);
+    }
+  },
+);
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  extraReducers: {
+    [fetchMissions.pending]: () => {
+      console.log('fetching');
+    },
+    [fetchMissions.fulfilled]: (state, action) => {
+      console.log('success');
+      state.missions = action.payload;
+    },
+
+  },
+});
+
+export default missionsSlice.reducer;

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -9,10 +9,15 @@ export const fetchMissions = createAsyncThunk(
   'missions/fetchMissions',
   async () => {
     const response = await fetch(missionsURL);
-    if (response.ok) {
-      const data = await response.json();
-      console.log(data);
-    }
+    const data = await response.json();
+    const missionsData = data.map((mission) => ({
+      id: mission.mission_id,
+      name: mission.mission_name,
+      description: mission.description,
+    }));
+    console.log(missionsData);
+
+    return missionsData;
   },
 );
 


### PR DESCRIPTION
## In this branch I fetch teh missions data from the API:
Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

- Once the data are fetched, dispatch an action to store the selected data in Redux store:

> - mission_id
> - mission_name
> - description

- NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation).

